### PR TITLE
Revert "Fix for interpretation of power consumption and energy output"

### DIFF
--- a/HA-Lambda-WP_configuration.yaml
+++ b/HA-Lambda-WP_configuration.yaml
@@ -266,7 +266,6 @@ modbus:
           device_class: energy
           state_class: total_increasing
           scale: 1
-          swap: word
           precision: 0
           data_type: int32
         - name: EU13L_Hp1_Compressor_Thermal_Energy_Output_accumulated
@@ -276,7 +275,6 @@ modbus:
           device_class: energy
           state_class: total_increasing
           scale: 1
-          swap: word
           precision: 0
           data_type: int32
 # Boiler  --for additonal boiler, this section needs to be duplicated and second digit of address increased by 1--


### PR DESCRIPTION
Reverts RalfWinter/lambda-heatpump-modbus-tcp-HA#36

Didn't Work for me, old version without swap statement works perfect, please check your environment:

Lambda GUI:
<img width="888" height="259" alt="grafik" src="https://github.com/user-attachments/assets/088263df-1c76-488a-a52c-d5700914ed4b" />

HA:
<img width="613" height="110" alt="grafik" src="https://github.com/user-attachments/assets/8de884d7-9691-45ba-88bb-f0230b5962b2" />
